### PR TITLE
Add Textmate keymap bindings

### DIFF
--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -1,0 +1,49 @@
+[
+  {
+    "bindings": {}
+  },
+  {
+    "context": "Editor",
+    "bindings": {
+      "cmd-b": "editor::GoToDefinition",
+      "cmd-g": "editor::SelectNext",
+      "cmd-shift-g": "editor::SelectPrevious",
+      "cmd-j": "editor::ScrollCursorCenter",
+      "cmd-backspace": "editor::DeleteToBeginningOfLine"
+    }
+  },
+  {
+    "context": "Editor && mode == full",
+    "bindings": {}
+  },
+  {
+    "context": "BufferSearchBar",
+    "bindings": {
+      "ctrl-s": "search::SelectNextMatch",
+      "ctrl-shift-s": "search::SelectPrevMatch"
+    }
+  },
+  {
+    "context": "Workspace",
+    "bindings": {
+      "cmd-alt-ctrl-d": "workspace::ToggleLeftSidebar",
+      "cmd-t": "file_finder::Toggle",
+      "cmd-shift-t": "project_symbols::Toggle"
+    }
+  },
+  {
+    "context": "Pane",
+    "bindings": {
+      "alt-cmd-r": "search::ToggleRegex",
+      "ctrl-tab": "project_panel::ToggleFocus"
+    }
+  },
+  {
+    "context": "ProjectPanel",
+    "bindings": {}
+  },
+  {
+    "context": "Dock",
+    "bindings": {}
+  }
+]

--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -1,7 +1,7 @@
 [
   {
     "bindings": {
-      "cmd-shift-o": "recent_projects::Toggle",
+      "cmd-shift-o": "recent_projects::Toggle"
     }
   },
   {
@@ -51,7 +51,7 @@
         }
       ],
       "ctrl-shift-left": "editor::SelectToPreviousSubwordStart",
-      "ctrl-shift-right": "editor::SelectToNextSubwordEnd",
+      "ctrl-shift-right": "editor::SelectToNextSubwordEnd"
     }
   },
   {

--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -81,7 +81,9 @@
   },
   {
     "context": "ProjectPanel",
-    "bindings": {}
+    "bindings": {
+      "enter": "project_panel::Rename"
+    }
   },
   {
     "context": "Dock",

--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -1,26 +1,57 @@
 [
   {
     "bindings": {
-      "cmd-shift-[": "pane::ActivatePrevItem",
-      "cmd-shift-]": "pane::ActivateNextItem"
+      "cmd-shift-o": "recent_projects::Toggle",
     }
   },
   {
     "context": "Editor",
     "bindings": {
-      "cmd-=": "zed::IncreaseBufferFontSize",
-      "cmd--": "zed::DecreaseBufferFontSize",
-      "cmd-_": "zed::IncreaseBufferFontSize",
-      "cmd-+": "zed::DecreaseBufferFontSize",
-      "cmd-b": "editor::GoToDefinition",
-      "cmd-g": "editor::SelectNext",
-      "cmd-shift-g": "editor::SelectPrevious",
-      "cmd-j": "editor::ScrollCursorCenter",
-      "cmd-backspace": "editor::DeleteToBeginningOfLine",
+      "cmd-l": "editor::ToggleGoToLine",
       "ctrl-shift-d": "editor::DuplicateLine",
-      "cmd-return": "editor::NewlineBelow",
-      "cmd-ctrljq-up": "editor::MoveLineUp",
-      "cmd-ctrl-down": "editor::MoveLineDown"
+      "cmd-b": "editor::GoToDefinition",
+      "cmd-j": "editor::ScrollCursorCenter",
+      "cmd-enter": "editor::NewlineBelow",
+      "cmd-shift-l": "editor::SelectLine",
+
+      "alt-backspace": "editor::DeleteToPreviousWordStart",
+      "alt-shift-backspace": "editor::DeleteToNextWordEnd",
+      "alt-delete": "editor::DeleteToNextWordEnd",
+      "alt-shift-delete": "editor::DeleteToNextWordEnd",
+      "ctrl-backspace": "editor::DeleteToPreviousSubwordStart",
+      "ctrl-delete": "editor::DeleteToNextSubwordEnd",
+
+      "alt-left": [
+        "editor::MoveToPreviousWordStart",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "alt-right":[
+        "editor::MoveToNextWordEnd",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "ctrl-left": "editor::MoveToPreviousSubwordStart",
+      "ctrl-right": "editor::MoveToNextSubwordEnd",
+
+      "cmd-shift-left": "editor::SelectToBeginningOfLine",
+      "cmd-shift-right": "editor::SelectToEndOfLine",
+      "alt-shift-left": [
+        "editor::SelectToBeginningOfLine",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "alt-shift-right": [
+        "editor::SelectToEndOfLine",
+        {
+          "stop_at_soft_wraps": true
+        }
+      ],
+      "ctrl-shift-left": "editor::SelectToPreviousSubwordStart",
+      "ctrl-shift-right": "editor::SelectToNextSubwordEnd",
     }
   },
   {

--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -1,15 +1,26 @@
 [
   {
-    "bindings": {}
+    "bindings": {
+      "cmd-shift-[": "pane::ActivatePrevItem",
+      "cmd-shift-]": "pane::ActivateNextItem"
+    }
   },
   {
     "context": "Editor",
     "bindings": {
+      "cmd-=": "zed::IncreaseBufferFontSize",
+      "cmd--": "zed::DecreaseBufferFontSize",
+      "cmd-_": "zed::IncreaseBufferFontSize",
+      "cmd-+": "zed::DecreaseBufferFontSize",
       "cmd-b": "editor::GoToDefinition",
       "cmd-g": "editor::SelectNext",
       "cmd-shift-g": "editor::SelectPrevious",
       "cmd-j": "editor::ScrollCursorCenter",
-      "cmd-backspace": "editor::DeleteToBeginningOfLine"
+      "cmd-backspace": "editor::DeleteToBeginningOfLine",
+      "ctrl-shift-d": "editor::DuplicateLine",
+      "cmd-return": "editor::NewlineBelow",
+      "cmd-ctrljq-up": "editor::MoveLineUp",
+      "cmd-ctrl-down": "editor::MoveLineDown"
     }
   },
   {
@@ -26,7 +37,7 @@
   {
     "context": "Workspace",
     "bindings": {
-      "cmd-alt-ctrl-d": "workspace::ToggleLeftSidebar",
+      "cmd-alt-ctrl-d": "workspaceLeft",
       "cmd-t": "file_finder::Toggle",
       "cmd-shift-t": "project_symbols::Toggle"
     }

--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -1,7 +1,8 @@
 [
   {
     "bindings": {
-      "cmd-shift-o": "projects::OpenRecent"
+      "cmd-shift-o": "projects::OpenRecent",
+      "cmd-alt-tab": "project_panel::ToggleFocus"
     }
   },
   {

--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -1,13 +1,13 @@
 [
   {
     "bindings": {
-      "cmd-shift-o": "recent_projects::Toggle"
+      "cmd-shift-o": "projects::OpenRecent"
     }
   },
   {
     "context": "Editor",
     "bindings": {
-      "cmd-l": "editor::ToggleGoToLine",
+      "cmd-l": "go_to_line::Toggle",
       "ctrl-shift-d": "editor::DuplicateLine",
       "cmd-b": "editor::GoToDefinition",
       "cmd-j": "editor::ScrollCursorCenter",
@@ -20,14 +20,13 @@
       "alt-shift-delete": "editor::DeleteToNextWordEnd",
       "ctrl-backspace": "editor::DeleteToPreviousSubwordStart",
       "ctrl-delete": "editor::DeleteToNextSubwordEnd",
-
       "alt-left": [
         "editor::MoveToPreviousWordStart",
         {
           "stop_at_soft_wraps": true
         }
       ],
-      "alt-right":[
+      "alt-right": [
         "editor::MoveToNextWordEnd",
         {
           "stop_at_soft_wraps": true
@@ -35,7 +34,6 @@
       ],
       "ctrl-left": "editor::MoveToPreviousSubwordStart",
       "ctrl-right": "editor::MoveToNextSubwordEnd",
-
       "cmd-shift-left": "editor::SelectToBeginningOfLine",
       "cmd-shift-right": "editor::SelectToEndOfLine",
       "alt-shift-left": [
@@ -68,7 +66,7 @@
   {
     "context": "Workspace",
     "bindings": {
-      "cmd-alt-ctrl-d": "workspaceLeft",
+      "cmd-alt-ctrl-d": "workspace::ToggleLeftSidebar",
       "cmd-t": "file_finder::Toggle",
       "cmd-shift-t": "project_symbols::Toggle"
     }

--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -13,7 +13,7 @@
       "cmd-j": "editor::ScrollCursorCenter",
       "cmd-enter": "editor::NewlineBelow",
       "cmd-shift-l": "editor::SelectLine",
-
+      "cmd-shift-t": "outline::Toggle",
       "alt-backspace": "editor::DeleteToPreviousWordStart",
       "alt-shift-backspace": "editor::DeleteToNextWordEnd",
       "alt-delete": "editor::DeleteToNextWordEnd",

--- a/textmate/keymap.json
+++ b/textmate/keymap.json
@@ -81,9 +81,7 @@
   },
   {
     "context": "ProjectPanel",
-    "bindings": {
-      "enter": "project_panel::Rename"
-    }
+    "bindings": {}
   },
   {
     "context": "Dock",


### PR DESCRIPTION
## What?

- [x] Add keymap bindings to replicate [TextMate](https://macromates.com) behaviour in Zed
- [x] Test in Zed

## Why?

I've been using TextMate near-daily since 2006, these key bindings are seared into my muscle memory. I'm sure others will be in the same position, given the longevity and popularity of the editor.

Haven't gotten my hands on a release yet, so this is all currently untested in Zed. Pieced this together by reading the atom & jetbrains keymaps, [the keybindings documentation](https://zed.dev/docs/configuration/key-bindings) and the [default.json](https://zed.dev/ref/default.json) keymaps. And some educated guesses at the action naming scheme. 🙃 