### PR TITLE
Update jetbrains keymap with advance downward option on comment toggle

### DIFF
--- a/jetbrains/keymap.json
+++ b/jetbrains/keymap.json
@@ -24,6 +24,12 @@
           "replace_newest": false
         }
       ],
+      "cmd-/": [
+        "editor::ToggleComments",
+        {
+          "advance_downwards": true
+        }
+      ],
       "shift-alt-up": "editor::MoveLineUp",
       "shift-alt-down": "editor::MoveLineDown",
       "cmd-[": "pane::GoBack",


### PR DESCRIPTION
Merge when stable is at v0.75.x (March 1st, 2023).

Closes: https://github.com/zed-industries/community/issues/964