### PR TITLE
Add newline below and above shortcuts

### DIFF
--- a/src/atom.json
+++ b/src/atom.json
@@ -18,7 +18,9 @@
       ],
       "ctrl-shift-down": "editor::AddSelectionBelow",
       "ctrl-shift-up": "editor::AddSelectionAbove",
-      "cmd-shift-backspace": "editor::DeleteToBeginningOfLine"
+      "cmd-shift-backspace": "editor::DeleteToBeginningOfLine",
+      "cmd-shift-enter": "editor::NewlineAbove",
+      "cmd-enter": "editor::NewlineBelow"
     }
   },
   {

--- a/src/jetbrains.json
+++ b/src/jetbrains.json
@@ -14,6 +14,7 @@
       "cmd-pagedown": "editor::MovePageDown",
       "cmd-pageup": "editor::MovePageUp",
       "ctrl-alt-shift-b": "editor::SelectToPreviousWordStart",
+      "cmd-alt-enter": "editor::NewlineAbove",
       "shift-enter": "editor::NewlineBelow",
       "cmd--": "editor::Fold",
       "cmd-=": "editor::UnfoldLines",

--- a/src/sublime_text.json
+++ b/src/sublime_text.json
@@ -24,7 +24,9 @@
       "ctrl-.": "editor::GoToHunk",
       "ctrl-,": "editor::GoToPrevHunk",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
-      "ctrl-delete": "editor::DeleteToNextWordEnd"
+      "ctrl-delete": "editor::DeleteToNextWordEnd",
+      "cmd-shift-enter": "editor::NewlineAbove",
+      "cmd-enter": "editor::NewlineBelow"
     }
   },
   {

--- a/src/textmate.json
+++ b/src/textmate.json
@@ -12,6 +12,7 @@
       "ctrl-shift-d": "editor::DuplicateLine",
       "cmd-b": "editor::GoToDefinition",
       "cmd-j": "editor::ScrollCursorCenter",
+      "cmd-alt-enter": "editor::NewlineAbove",
       "cmd-enter": "editor::NewlineBelow",
       "cmd-shift-l": "editor::SelectLine",
       "cmd-shift-t": "outline::Toggle",


### PR DESCRIPTION
We have added a `editor::NewlineAbove` action to complement the existing `editor::NewlineBelow` action.

The default Zed shortcuts are `cmd-enter` for below and `cmd-shift-enter` for above. To the best of my knowledge I introduced the shortcuts for the four editor keymaps we maintain.