### PR TITLE
More like jetbrains

### DIFF
--- a/src/jetbrains.json
+++ b/src/jetbrains.json
@@ -34,6 +34,7 @@
       ],
       "shift-alt-up": "editor::MoveLineUp",
       "shift-alt-down": "editor::MoveLineDown",
+      "cmd-alt-l": "editor::Format",
       "cmd-[": "pane::GoBack",
       "cmd-]": "pane::GoForward",
       "alt-f7": "editor::FindAllReferences",

--- a/src/jetbrains.json
+++ b/src/jetbrains.json
@@ -11,6 +11,7 @@
       "ctrl->": "zed::IncreaseBufferFontSize",
       "ctrl-<": "zed::DecreaseBufferFontSize",
       "cmd-d": "editor::DuplicateLine",
+      "cmd-backspace": "editor::DeleteLine",
       "cmd-pagedown": "editor::MovePageDown",
       "cmd-pageup": "editor::MovePageUp",
       "ctrl-alt-shift-b": "editor::SelectToPreviousWordStart",

--- a/src/jetbrains.json
+++ b/src/jetbrains.json
@@ -64,6 +64,7 @@
   {
     "context": "Workspace",
     "bindings": {
+      "cmd-shift-o": "file_finder::Toggle",
       "cmd-shift-a": "command_palette::Toggle",
       "cmd-alt-o": "project_symbols::Toggle",
       "cmd-1": "workspace::ToggleLeftSidebar",


### PR DESCRIPTION
This PR adds some keybindings to make the jetbrains keybindings more like jetbrains
* cmd-backspace to delete a whole line
* cmd-shift-o to toggle file finder
* cmd-alt-l to format code