### PR TITLE
Add Cmd-1 through 9 tab switching from Atom

### DIFF
--- a/src/atom.json
+++ b/src/atom.json
@@ -55,7 +55,40 @@
     "context": "Pane",
     "bindings": {
       "alt-cmd-/": "search::ToggleRegex",
-      "ctrl-0": "project_panel::ToggleFocus"
+      "ctrl-0": "project_panel::ToggleFocus",
+      "cmd-1": [
+        "pane::ActivateItem",
+        0
+      ],
+      "cmd-2": [
+        "pane::ActivateItem",
+        1
+      ],
+      "cmd-3": [
+        "pane::ActivateItem",
+        2
+      ],
+      "cmd-4": [
+        "pane::ActivateItem",
+        3
+      ],
+      "cmd-5": [
+        "pane::ActivateItem",
+        4
+      ],
+      "cmd-6": [
+        "pane::ActivateItem",
+        5
+      ],
+      "cmd-7": [
+        "pane::ActivateItem",
+        6
+      ],
+      "cmd-8": [
+        "pane::ActivateItem",
+        7
+      ],
+      "cmd-9": "pane::ActivateLastItem"
     }
   },
   {


### PR DESCRIPTION
This patch adds the feature from Atom where:
 - Pushing Cmd + 1 to 8 selects tab 1, 2, 3.. 8
 - Pushing Cmd + 9 selects the final tab in the pane

If the key bindings are based on VS Code, this feature
should actually be in the base keymap, but the base keymap
isn't open source, so this is the best PR I can make as
an outside developer :)
