### PR TITLE
Add TextMate text casing commands

### DIFF
--- a/src/textmate.json
+++ b/src/textmate.json
@@ -12,6 +12,8 @@
       "ctrl-shift-d": "editor::DuplicateLine",
       "cmd-b": "editor::GoToDefinition",
       "cmd-j": "editor::ScrollCursorCenter",
+      "cmd-enter": "editor::NewlineBelow",
+      "cmd-alt-enter": "editor::NewLineAbove",
       "cmd-shift-l": "editor::SelectLine",
       "cmd-shift-t": "outline::Toggle",
       "alt-backspace": "editor::DeleteToPreviousWordStart",
@@ -54,9 +56,7 @@
   },
   {
     "context": "Editor && mode == full",
-    "bindings": {
-      "cmd-alt-enter": "editor::NewlineAbove"
-    }
+    "bindings": {}
   },
   {
     "context": "BufferSearchBar",

--- a/src/textmate.json
+++ b/src/textmate.json
@@ -51,7 +51,8 @@
         }
       ],
       "ctrl-shift-left": "editor::SelectToPreviousSubwordStart",
-      "ctrl-shift-right": "editor::SelectToNextSubwordEnd"
+      "ctrl-shift-right": "editor::SelectToNextSubwordEnd",
+      "ctrl-w": "editor::SelectNext",
     }
   },
   {

--- a/src/textmate.json
+++ b/src/textmate.json
@@ -53,6 +53,10 @@
       "ctrl-shift-left": "editor::SelectToPreviousSubwordStart",
       "ctrl-shift-right": "editor::SelectToNextSubwordEnd",
       "ctrl-w": "editor::SelectNext",
+      "ctrl-u": "editor::ConvertToUpperCase",
+      "ctrl-shift-u": "editor::ConvertToLowerCase",
+      "ctrl-alt-u": "editor::ConvertToUpperCamelCase",
+      "ctrl-_": "editor::ConvertToSnakeCase"
     }
   },
   {

--- a/src/textmate.json
+++ b/src/textmate.json
@@ -83,5 +83,9 @@
   {
     "context": "ProjectPanel",
     "bindings": {}
+  },
+  {
+    "context": "Dock",
+    "bindings": {}
   }
 ]


### PR DESCRIPTION
Take advantage of the new case conversion commands by mapping them to TextMate key combos.

Zed also added the Dock block, so I've left that in. And added back the NewlineBelow/NewlineAbove combos from #25 which have gone AWOL