### PR TITLE
[Jetbrains] Add 'enter' to open file in project panel

### DIFF
--- a/src/jetbrains.json
+++ b/src/jetbrains.json
@@ -77,5 +77,11 @@
       "cmd-1": "workspace::ToggleLeftDock",
       "cmd-6": "diagnostics::Deploy"
     }
+  },
+  {
+    "context": "ProjectPanel",
+    "bindings": {
+      "enter": "project_panel::Open"
+    }
   }
 ]


### PR DESCRIPTION
In Jetbrains IDEs when you open project panel with cmd/alt + 1 to open selected file you should press 'enter'
https://github.com/zed-industries/community/issues/1750