### PR TITLE
fixes incorrect assignment for jetbrains unfoldlines

### DIFF
--- a/src/jetbrains.json
+++ b/src/jetbrains.json
@@ -18,7 +18,7 @@
       "cmd-alt-enter": "editor::NewlineAbove",
       "shift-enter": "editor::NewlineBelow",
       "cmd--": "editor::Fold",
-      "cmd-=": "editor::UnfoldLines",
+      "cmd-+": "editor::UnfoldLines",
       "alt-shift-g": "editor::SplitSelectionIntoLines",
       "ctrl-g": [
         "editor::SelectNext",


### PR DESCRIPTION
This fixes an incorrect key binding for jetbrains.

https://www.jetbrains.com/help/idea/reference-keymap-mac-default.html#code_folding

<img width="857" alt="Screen Shot 2023-11-10 at 2 52 19 PM" src="https://github.com/zed-industries/keymaps/assets/37887/44277d98-8057-4113-8c38-eb033b2606fd">
